### PR TITLE
fix: unpin patch versions from serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ directories = "5.0.1"
 once_cell = "1.20.3"
 posthog-rs = { git = "https://github.com/Romsters/posthog-rs", rev = "a54b1423100beaaa5d7eb43ff801f4b8389f9550", features = ["async-client"] }
 sentry = { version = "0.35.0", default-features = false, features = ["reqwest", "rustls", "test"] }
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "2.0.4"
 uuid = { version = "1.11.0", features = ["v4", "serde"] }
 


### PR DESCRIPTION
As this repository is meant to be used by other repositories, the use of pinned patch versions causes incompatibility in including this library in other upstream projects like [foundry-zksync](https://github.com/matter-labs/foundry-zksync/blob/main/Cargo.toml#L332) that often need to pin exact versions due to stringent requirements.